### PR TITLE
Install BepInEx from SpaceWarp ZIP, add missing SpaceWarp folder

### DIFF
--- a/NetKAN/BepInEx.netkan
+++ b/NetKAN/BepInEx.netkan
@@ -1,6 +1,7 @@
-spec_version: v1.31
+spec_version: v1.32
 identifier: BepInEx
-$kref: '#/ckan/spacedock/3255'
+$kref: '#/ckan/spacedock/3277'
+x_netkan_epoch: 1
 license: LGPL-3.0
 tags:
   - plugin
@@ -8,6 +9,9 @@ tags:
 install:
   - find: BepInEx
     install_to: GameRoot
+    include_only:
+      - config
+      - core
   - file: doorstop_config.ini
     install_to: GameRoot
   - file: winhttp.dll

--- a/NetKAN/BepInEx.netkan
+++ b/NetKAN/BepInEx.netkan
@@ -1,5 +1,7 @@
 spec_version: v1.32
 identifier: BepInEx
+name: BepInEx
+abstract: Modloader for Unity games
 $kref: '#/ckan/spacedock/3277'
 x_netkan_epoch: 1
 license: LGPL-3.0

--- a/NetKAN/SpaceWarp.netkan
+++ b/NetKAN/SpaceWarp.netkan
@@ -1,5 +1,6 @@
 spec_version: v1.32
 identifier: SpaceWarp
+name: SpaceWarp
 $kref: '#/ckan/spacedock/3277'
 $vref: '#/ckan/space-warp'
 license: MIT

--- a/NetKAN/SpaceWarp.netkan
+++ b/NetKAN/SpaceWarp.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.31
+spec_version: v1.32
 identifier: SpaceWarp
 $kref: '#/ckan/spacedock/3277'
 $vref: '#/ckan/space-warp'
@@ -9,7 +9,8 @@ tags:
 depends:
   - name: BepInEx
 install:
-  - find: ConfigurationManager
-    install_to: BepInEx/plugins
-  - find: SpaceWarp
-    install_to: BepInEx/plugins
+  - find: BepInEx
+    install_to: GameRoot
+    include_only:
+      - patchers
+      - plugins


### PR DESCRIPTION
## Problems

See #15 and #16:

- The original BepInEx upload isn't being updated anymore (https://spacedock.info/mod/3255/BepInEx%20for%20KSP%202)
- SpaceWarp is now bundling a fresher version of BepInEx (https://spacedock.info/mod/3277/Space%20Warp%20+%20BepInEx)
- SpaceWarp needs `BepInEx/patchers` to be installed, but it's not included in the netkan

## Changes

- Now the BepInEx netkan is switched to download from the bundled BepInEx+SpaceWarp download, installing only the `core` and `config` folders since these are for BepInEx
- BepInEx is epoch'd because its release versioning will now align with SpaceWarp's (and 1.1.1 is less than 5.4.21)
- Now the SpaceWarp netkan is updated to install only the `patchers` and `plugins` folders since these are for SpaceWarp
- The `spec_version`s are updated to 1.32 since that's the minimum CKAN version for KSP2 mods (it was only lower before because the release wasn't out yet)

This should maintain the independence of the two modules while fixing the problems with how the current versions are installed. Mods that only depend on BepInEx (LGG wrote one) will still be able to have just that dependency installed.

Fixes #16.
