### PR TITLE
Added dependency to LFO and recomendation to LOABE

### DIFF
--- a/NetKAN/SORRY.netkan
+++ b/NetKAN/SORRY.netkan
@@ -8,6 +8,10 @@ tags:
   - parts
 depends:
   - name: SpaceWarp
+  - name: [LFO] Lux's Flames and Ornaments
+recommends:
+  - name: LuxsOABExtensions
+  - name: CommunityFixes
 install:
   - find: BepInEx
     install_to: GameRoot


### PR DESCRIPTION
Recommendation is due to engine covers having multiple symmetry nodes, this way players dont have to put each by themselves. Change LFO's identifier accordingly please
This dependency only comes for SORRY 0.3+