### PR TITLE
Add NodeManager depends for ManeuverNodeController

### DIFF
--- a/NetKAN/ManeuverNodeController.netkan
+++ b/NetKAN/ManeuverNodeController.netkan
@@ -8,6 +8,7 @@ tags:
   - convenience
 depends:
   - name: SpaceWarp
+  - name: NodeManager
 install:
   - find: maneuver_node_controller
     install_to: BepInEx/plugins


### PR DESCRIPTION
The warning from KSP-CKAN/CKAN#3827 has caught a newly added dependency:

![image](https://github.com/KSP-CKAN/KSP2-NetKAN/assets/1559108/17c03a99-5cdf-4379-968b-30ffe2d457c0)

Confirmed in the mod's repo:

https://github.com/schlosrat/ManeuverNodeController/commit/c3603df42e71023cc620b43d1cf9c7478033bfcc
