### PR TITLE
Update the UitkForKsp2 identifier

### DIFF
--- a/NetKAN/ShadowUtilityLIB.netkan
+++ b/NetKAN/ShadowUtilityLIB.netkan
@@ -8,4 +8,4 @@ tags:
   - library
 depends:
   - name: SpaceWarp
-  - name: UITKforKSP2
+  - name: UitkForKsp2

--- a/NetKAN/SpaceWarp.netkan
+++ b/NetKAN/SpaceWarp.netkan
@@ -9,7 +9,7 @@ tags:
   - library
 depends:
   - name: BepInEx
-  - name: UITKforKSP2
+  - name: UitkForKsp2
 install:
   - find: BepInEx
     install_to: GameRoot

--- a/NetKAN/UITKforKSP2.netkan
+++ b/NetKAN/UITKforKSP2.netkan
@@ -1,5 +1,5 @@
 spec_version: v1.32
-identifier: UITKforKSP2
+identifier: UitkForKsp2
 $kref: '#/ckan/spacedock/3363'
 $vref: '#/ckan/space-warp'
 license: MIT


### PR DESCRIPTION
UitkForKsp2 is the conventional way to capitalize acronyms in most programming languages (see [HttpContext](https://learn.microsoft.com/en-us/dotnet/api/system.web.httpcontext) for example). The original identifier (UITKforKSP2) was automatically generated from the name of the mod on SpaceDock.