### PR TITLE
Update Inputbinder dependencies

### DIFF
--- a/NetKAN/Inputbinder.netkan
+++ b/NetKAN/Inputbinder.netkan
@@ -4,6 +4,8 @@ $kref: '#/ckan/spacedock/3422'
 license: MIT
 tags:
   - plugin
+depends:
+  - name: BepInEx
 install:
   - find: inputbinder
     install_to: BepInEx/plugins


### PR DESCRIPTION
Add missing BepInEx dependency.

(Missed in #68.)
