### PR TITLE
Add install stanzas to KSP2 mods using the default

### DIFF
--- a/NetKAN/EvenBetterTimeWarp.netkan
+++ b/NetKAN/EvenBetterTimeWarp.netkan
@@ -7,4 +7,6 @@ tags:
   - plugin
 depends:
   - name: SpaceWarp
-x_via: Automated SpaceDock CKAN submission
+install:
+  - find: EvenBetterTimeWarp
+    install_to: BepInEx/plugins

--- a/NetKAN/LazyOrbit.netkan
+++ b/NetKAN/LazyOrbit.netkan
@@ -7,4 +7,6 @@ tags:
   - plugin
 depends:
   - name: SpaceWarp
-x_via: Automated SpaceDock CKAN submission
+install:
+  - find: LazyOrbit
+    install_to: BepInEx/plugins

--- a/NetKAN/LuxsOABExtensions.netkan
+++ b/NetKAN/LuxsOABExtensions.netkan
@@ -8,3 +8,6 @@ tags:
   - editor
 depends:
   - name: SpaceWarp
+install:
+  - find: LuxsOABExtensions
+    install_to: BepInEx/plugins

--- a/NetKAN/ShadowUtilityLIB.netkan
+++ b/NetKAN/ShadowUtilityLIB.netkan
@@ -9,3 +9,6 @@ tags:
 depends:
   - name: SpaceWarp
   - name: UITKforKSP2
+install:
+  - find: ShadowUtilityLIB
+    install_to: BepInEx/plugins

--- a/NetKAN/UIScaler.netkan
+++ b/NetKAN/UIScaler.netkan
@@ -7,3 +7,6 @@ tags:
   - plugin
 depends:
   - name: SpaceWarp
+install:
+  - find: UIScaler
+    install_to: BepInEx/plugins


### PR DESCRIPTION
## Motivation

The KSP2 modding ecosystem is starting to flirt with putting mods in `GameData/Mods` instead of `BepInEx/plugins` (see #68 and #70). This is expected to be the install location for the official mod loader (but this is not finalized yet and could still be changed). When this happens, we are going to have to change the default install path, which means any mods using the default install stanza would have their install paths silently changed. This is bad.

## Changes

Now all KSP2 netkans without `install` properties have one added. This will allow us to change the default in a future CKAN client without disruption.
