### PR TITLE
Tags for FancyFuelTanks

### DIFF
--- a/NetKAN/FancyFuelTanks.netkan
+++ b/NetKAN/FancyFuelTanks.netkan
@@ -2,7 +2,8 @@ spec_version: v1.18
 identifier: FancyFuelTanks
 $kref: '#/ckan/spacedock/3431'
 license: MIT
+tags:
+  - parts
 install:
   - find: FFT
     install_to: BepInEx/plugins
-x_via: Automated SpaceDock CKAN submission


### PR DESCRIPTION
#73 was merged without adding [tags](https://github.com/KSP-CKAN/CKAN/wiki/Suggested-Tags). Now it's fixed.
