### PR TITLE
Force V for K2D2

### DIFF
--- a/NetKAN/K2D2.netkan
+++ b/NetKAN/K2D2.netkan
@@ -2,6 +2,7 @@ spec_version: v1.18
 identifier: K2D2
 $kref: '#/ckan/spacedock/3325'
 $vref: '#/ckan/space-warp'
+x_netkan_force_v: true
 license: CC-BY-SA
 tags:
   - plugin


### PR DESCRIPTION
'v' prefix got dropped:

![image](https://github.com/KSP-CKAN/KSP2-NetKAN/assets/1559108/d2f9ac88-4e56-499e-843f-0eace03b4ef3)

Now it'll always be there.

Closes KSP-CKAN/KSP2-CKAN-meta#4.

