### PR TITLE
Fix for HUMANS not installing flags folder to GameRoot

### DIFF
--- a/NetKAN/HUMANS.netkan
+++ b/NetKAN/HUMANS.netkan
@@ -10,4 +10,6 @@ depends:
 install:
   - find: Humans
     install_to: BepInEx/plugins
+  - find: flags
+    install_to: GameRoot
 x_via: Automated SpaceDock CKAN submission


### PR DESCRIPTION
Automatic SpaceDock PR didn't recognize that HUMANS also has a "flags" folder that needs to be installed.