### PR TITLE
Remove CheatsMenu's vref

### DIFF
--- a/NetKAN/CheatsMenu.netkan
+++ b/NetKAN/CheatsMenu.netkan
@@ -1,7 +1,6 @@
 spec_version: v1.18
 identifier: CheatsMenu
 $kref: '#/ckan/spacedock/3266'
-$vref: '#/ckan/space-warp'
 license: CC-BY-NC-ND
 tags:
   - plugin


### PR DESCRIPTION
![image](https://github.com/KSP-CKAN/KSP2-NetKAN/assets/1559108/0744ac99-a571-4baf-939d-aae2f93ba94b)

This mod no longer ships a `swinfo.json` file.

- https://spacedock.info/mod/3266/Cheats%20Menu
