### PR TITLE
Add first-person tag to applicable mods

### DIFF
--- a/NetKAN/KerbalView.netkan
+++ b/NetKAN/KerbalView.netkan
@@ -6,6 +6,7 @@ license: MIT
 tags:
   - plugin
   - crewed
+  - first-person
 depends:
   - name: SpaceWarp
 install:


### PR DESCRIPTION
A `first-person` tag has just been added to https://github.com/KSP-CKAN/CKAN/wiki/Suggested-Tags .

Now this tag is added to mods where it applies, courtesy of expert knowledge from @jan-bures.

Fixes part of #9859, but we have other pieces to take care of after this.

___

ckan compat add 0.1
