### PR TITLE
GitHub download fallbacks for applicable mods

### DIFF
--- a/NetKAN/BepInEx.netkan
+++ b/NetKAN/BepInEx.netkan
@@ -1,4 +1,29 @@
-spec_version: v1.32
+spec_version: v1.34
+identifier: BepInEx
+name: BepInEx
+abstract: Modloader for Unity games
+$kref: '#/ckan/github/SpaceWarpDev/SpaceWarp'
+x_netkan_epoch: 1
+x_netkan_version_edit:
+  find: 'spacewarp-'
+  replace: ''
+  strict: false
+license: LGPL-3.0
+tags:
+  - plugin
+  - library
+install:
+  - find: BepInEx
+    install_to: GameRoot
+    include_only:
+      - config
+      - core
+  - file: doorstop_config.ini
+    install_to: GameRoot
+  - file: winhttp.dll
+    install_to: GameRoot
+---
+spec_version: v1.34
 identifier: BepInEx
 name: BepInEx
 abstract: Modloader for Unity games

--- a/NetKAN/Blackskyskybox.netkan
+++ b/NetKAN/Blackskyskybox.netkan
@@ -1,12 +1,27 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: Blackskyskybox
+$kref: '#/ckan/github/Bit-Studios/konfig/asset_match/BlackSky.zip'
+x_netkan_version_edit:
+  find: 'SkyboxBlackSky64x'
+  replace: '1.0.0'
+  strict: false
+tags:
+  - config
+license: MIT
+depends:
+  - name: Konfig
+install:
+  - find: BlackSky
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: Blackskyskybox
 $kref: '#/ckan/spacedock/3502'
 tags:
   - config
 license: MIT
+depends:
+  - name: Konfig
 install:
   - find: BlackSky
     install_to: BepInEx/plugins
-depends:
-  - name: Konfig
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/BurnController.netkan
+++ b/NetKAN/BurnController.netkan
@@ -1,4 +1,26 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: BurnController
+$kref: '#/ckan/github/JohnsterSpaceProgramOfficial/BurnController'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: '^v'
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - plugin
+  - control
+depends:
+  - name: SpaceWarp
+install:
+  - find: BurnController
+    install_to: BepInEx/plugins
+x_netkan_override:
+  - version: '0.8.1'
+    override:
+      ksp_version_max: '0.1.1'
+---
+spec_version: v1.34
 identifier: BurnController
 $kref: '#/ckan/spacedock/3330'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/CommunityFixes.netkan
+++ b/NetKAN/CommunityFixes.netkan
@@ -1,4 +1,26 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: CommunityFixes
+$kref: '#/ckan/github/KSP2Community/CommunityFixes'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: '^v'
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - plugin
+depends:
+  - name: SpaceWarp
+  - name: PatchManager
+install:
+  - find: CommunityFixes
+    install_to: BepInEx/plugins
+x_netkan_override:
+  - version: '0.11.0'
+    override:
+      ksp_version_max: '0.2.0'
+---
+spec_version: v1.34
 identifier: CommunityFixes
 $kref: '#/ckan/spacedock/3301'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/CommunityResources.netkan
+++ b/NetKAN/CommunityResources.netkan
@@ -1,4 +1,24 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: CommunityResources
+$kref: '#/ckan/github/KSP2Community/CommunityResources'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: '^v'
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - plugin
+  - library
+  - config
+depends:
+  - name: SpaceWarp
+  - name: PatchManager
+install:
+  - find: CommunityResources
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: CommunityResources
 $kref: '#/ckan/spacedock/3484'
 $vref: '#/ckan/space-warp'
@@ -13,4 +33,3 @@ depends:
 install:
   - find: CommunityResources
     install_to: BepInEx/plugins
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/DockingAlignmentDisplay.netkan
+++ b/NetKAN/DockingAlignmentDisplay.netkan
@@ -1,4 +1,22 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: DockingAlignmentDisplay
+$kref: '#/ckan/github/Safarte/DockingAlignmentDisplay'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: '^v'
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - plugin
+depends:
+  - name: SpaceWarp
+  - name: UITKforKSP2
+install:
+  - find: DockingAlignmentDisplay
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: DockingAlignmentDisplay
 $kref: '#/ckan/spacedock/3439'
 $vref: '#/ckan/space-warp'
@@ -11,4 +29,3 @@ depends:
 install:
   - find: DockingAlignmentDisplay
     install_to: BepInEx/plugins
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/EVAAnarchy.netkan
+++ b/NetKAN/EVAAnarchy.netkan
@@ -1,4 +1,17 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: EVAAnarchy
+$kref: '#/ckan/github/ThunderousEcho/EvaAnarchy'
+$vref: '#/ckan/space-warp'
+license: MIT
+tags:
+  - plugin
+depends:
+  - name: SpaceWarp
+install:
+  - find: eva_anarchy
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: EVAAnarchy
 $kref: '#/ckan/spacedock/3341'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/FancyFuelTanks.netkan
+++ b/NetKAN/FancyFuelTanks.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.18
+spec_version: v1.34
 identifier: FancyFuelTanks
 name: Fancy Fuel Tanks
 abstract: FFT adds visually appealing Fuel Tanks to KSP2!
@@ -9,9 +9,21 @@ x_netkan_version_edit:
   strict: false
 $vref: '#/ckan/space-warp'
 license: MIT
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/topic/218451-*
-  spacedock: https://spacedock.info/mod/3431/Fancy%20Fuel%20Tanks
+tags:
+  - parts
+depends:
+  - name: SpaceWarp
+install:
+  - find_regexp: FFT.*
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
+identifier: FancyFuelTanks
+name: Fancy Fuel Tanks
+abstract: FFT adds visually appealing Fuel Tanks to KSP2!
+$kref: '#/ckan/spacedock/3431'
+$vref: '#/ckan/space-warp'
+license: MIT
 tags:
   - parts
 depends:

--- a/NetKAN/FlightPlan.netkan
+++ b/NetKAN/FlightPlan.netkan
@@ -1,4 +1,22 @@
-spec_version: v1.32
+spec_version: v1.34
+identifier: FlightPlan
+$kref: '#/ckan/github/schlosrat/FlightPlan'
+$vref: '#/ckan/space-warp'
+license: GPL-3.0
+tags:
+  - plugin
+  - information
+  - control
+depends:
+  - name: SpaceWarp
+  - name: NodeManager
+  - name: UITKforKSP2
+install:
+  - find: flight_plan
+    install_to: BepInEx/plugins
+    filter_regexp: \.pdb$
+---
+spec_version: v1.34
 identifier: FlightPlan
 $kref: '#/ckan/spacedock/3359'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/GalaxyTweaker.netkan
+++ b/NetKAN/GalaxyTweaker.netkan
@@ -1,4 +1,22 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: GalaxyTweaker
+$kref: '#/ckan/github/Hyperion-21/GalaxyTweaker'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - plugin
+  - planet-pack
+depends:
+  - name: SpaceWarp
+install:
+  - find: galaxy_tweaker
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: GalaxyTweaker
 $kref: '#/ckan/spacedock/3331'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/HideOrbits.netkan
+++ b/NetKAN/HideOrbits.netkan
@@ -1,4 +1,25 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: HideOrbits
+$kref: '#/ckan/github/ColinZeidler/KSP2-HideDistantOrbits'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - plugin
+depends:
+  - name: SpaceWarp
+install:
+  - find: HideOrbits
+    install_to: BepInEx/plugins
+x_netkan_override:
+  - version: '0.5.0'
+    override:
+      ksp_version_max: '0.2.0'
+---
+spec_version: v1.34
 identifier: HideOrbits
 $kref: '#/ckan/spacedock/3324'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/Inputbinder.netkan
+++ b/NetKAN/Inputbinder.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.18
+spec_version: v1.34
 identifier: Inputbinder
 $kref: '#/ckan/spacedock/3422'
 license: MIT
@@ -9,4 +9,15 @@ depends:
 install:
   - find: inputbinder
     install_to: BepInEx/plugins
-x_via: Automated SpaceDock CKAN submission
+---
+spec_version: v1.34
+identifier: Inputbinder
+$kref: '#/ckan/spacedock/3422'
+license: MIT
+tags:
+  - plugin
+depends:
+  - name: BepInEx
+install:
+  - find: inputbinder
+    install_to: BepInEx/plugins

--- a/NetKAN/Kalkulator.netkan
+++ b/NetKAN/Kalkulator.netkan
@@ -1,4 +1,26 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: Kalkulator
+$kref: '#/ckan/github/JohnsterSpaceProgramOfficial/Kalkulator'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: CC-BY-ND
+tags:
+  - plugin
+  - information
+depends:
+  - name: SpaceWarp
+install:
+  - find: kalkulator
+    install_to: BepInEx/plugins
+x_netkan_override:
+  - version: '1.0.2'
+    override:
+      ksp_version_max: '0.1.1'
+---
+spec_version: v1.34
 identifier: Kalkulator
 $kref: '#/ckan/spacedock/3327'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/KerbalLifeSupportSystem.netkan
+++ b/NetKAN/KerbalLifeSupportSystem.netkan
@@ -1,4 +1,30 @@
-spec_version: v1.24
+spec_version: v1.34
+identifier: KerbalLifeSupportSystem
+$kref: '#/ckan/github/Safarte/KerbalLifeSupportSystem'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - plugin
+  - parts
+  - crewed
+depends:
+  - name: UITKforKSP2
+  - name: SpaceWarp
+  - name: PatchManager
+  - name: CommunityResources
+install:
+  - find: KerbalLifeSupportSystem
+    install_to: BepInEx/plugins
+x_netkan_override:
+  - version: '0.5.2'
+    override:
+      ksp_version_max: '0.2.0'
+---
+spec_version: v1.34
 identifier: KerbalLifeSupportSystem
 $kref: '#/ckan/spacedock/3485'
 $vref: '#/ckan/space-warp'
@@ -13,6 +39,5 @@ depends:
   - name: PatchManager
   - name: CommunityResources
 install:
-  - find: 'KerbalLifeSupportSystem'
+  - find: KerbalLifeSupportSystem
     install_to: BepInEx/plugins
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/KerbonautManager.netkan
+++ b/NetKAN/KerbonautManager.netkan
@@ -1,4 +1,27 @@
-spec_version: v1.32
+spec_version: v1.34
+identifier: KerbonautManager
+$kref: '#/ckan/github/jan-bures/KerbonautManager'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - plugin
+  - editor
+  - crewed
+depends:
+  - name: SpaceWarp
+install:
+  - find: kerbonaut_manager
+    install_to: BepInEx/plugins
+x_netkan_override:
+  - version: '0.2.3'
+    override:
+      ksp_version_max: '0.2.0'
+---
+spec_version: v1.34
 identifier: KerbonautManager
 $kref: '#/ckan/spacedock/3310'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/KontrolSystem2.netkan
+++ b/NetKAN/KontrolSystem2.netkan
@@ -1,4 +1,25 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: KontrolSystem2
+$kref: '#/ckan/github/untoldwind/KontrolSystem2'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: MIT
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/214543-*
+  manual: https://kontrolsystem2.readthedocs.io/
+tags:
+  - plugin
+  - control
+depends:
+  - name: SpaceWarp
+install:
+  - find: KontrolSystem2
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: KontrolSystem2
 $kref: '#/ckan/spacedock/3316'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/LessWobbly.netkan
+++ b/NetKAN/LessWobbly.netkan
@@ -1,4 +1,17 @@
-spec_version: v1.31
+spec_version: v1.34
+identifier: LessWobbly
+$kref: '#/ckan/github/linuxgurugamer/KSP2-LessWobbly'
+license: MIT
+tags:
+  - plugin
+  - physics
+depends:
+  - name: BepInEx
+install:
+  - find: LessWobbly
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: LessWobbly
 $kref: '#/ckan/spacedock/3267'
 license: MIT

--- a/NetKAN/LuxsFlamesandOrnaments.netkan
+++ b/NetKAN/LuxsFlamesandOrnaments.netkan
@@ -1,4 +1,22 @@
-spec_version: v1.32
+spec_version: v1.34
+identifier: LuxsFlamesandOrnaments
+$kref: '#/ckan/github/KSP2Community/LFO'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: GPL-3.0
+tags:
+  - plugin
+  - graphics
+depends:
+  - name: SpaceWarp
+install:
+  - find: LFO
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: LuxsFlamesandOrnaments
 $kref: '#/ckan/spacedock/3383'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/ManeuverNodeController.netkan
+++ b/NetKAN/ManeuverNodeController.netkan
@@ -1,4 +1,20 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: ManeuverNodeController
+$kref: '#/ckan/github/schlosrat/ManeuverNodeController'
+$vref: '#/ckan/space-warp'
+license: CC-BY-NC-SA
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: SpaceWarp
+  - name: NodeManager
+  - name: UITKforKSP2
+install:
+  - find: maneuver_node_controller
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: ManeuverNodeController
 $kref: '#/ckan/spacedock/3270'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/OrbitalSurvey.netkan
+++ b/NetKAN/OrbitalSurvey.netkan
@@ -10,6 +10,7 @@ depends:
   - name: SpaceWarp
     min_version: 1.6.0
   - name: PatchManager
+  - name: UITKforKSP2
 install:
   - find: OrbitalSurvey
     install_to: BepInEx/plugins

--- a/NetKAN/PaigeBGone.netkan
+++ b/NetKAN/PaigeBGone.netkan
@@ -1,10 +1,21 @@
-spec_version: v1.18
+spec_version: v1.34
 identifier: PaigeBGone
 $kref: '#/ckan/github/amahlaka/P.A.I.G.E-B-Gone'
 $vref: '#/ckan/space-warp'
 license: MIT
-resources:
-  spacedock: https://spacedock.info/mod/3280/P.A.I.G.E-B-Gone
+tags:
+  - plugin
+depends:
+  - name: SpaceWarp
+install:
+  - find: paige_b_gone
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
+identifier: PaigeBGone
+$kref: '#/ckan/spacedock/3280'
+$vref: '#/ckan/space-warp'
+license: MIT
 tags:
   - plugin
 depends:

--- a/NetKAN/PatchManager.netkan
+++ b/NetKAN/PatchManager.netkan
@@ -1,4 +1,29 @@
-spec_version: v1.24
+spec_version: v1.34
+identifier: PatchManager
+$kref: '#/ckan/github/KSP2Community/PatchManager'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - plugin
+  - library
+depends:
+  - name: SpaceWarp
+install:
+  - find: BepInEx
+    install_to: GameRoot
+    include_only:
+      - patchers
+      - plugins
+x_netkan_override:
+  - version: '0.7.3'
+    override:
+      ksp_version_max: '0.2.0'
+---
+spec_version: v1.34
 identifier: PatchManager
 $kref: '#/ckan/spacedock/3482'
 $vref: '#/ckan/space-warp'
@@ -14,4 +39,3 @@ install:
     include_only:
       - patchers
       - plugins
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/ResonantOrbitCalculator.netkan
+++ b/NetKAN/ResonantOrbitCalculator.netkan
@@ -1,4 +1,22 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: ResonantOrbitCalculator
+$kref: '#/ckan/github/schlosrat/ResonantOrbitCalculator'
+$vref: '#/ckan/space-warp'
+license: MIT
+tags:
+  - plugin
+  - information
+depends:
+  - name: SpaceWarp
+install:
+  - find: resonant_orbit_calculator
+    install_to: BepInEx/plugins
+x_netkan_override:
+  - version: '0.6.2'
+    override:
+      ksp_version_max: '0.1.4'
+---
+spec_version: v1.34
 identifier: ResonantOrbitCalculator
 $kref: '#/ckan/spacedock/3332'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/SPARKTechnologies.netkan
+++ b/NetKAN/SPARKTechnologies.netkan
@@ -1,4 +1,22 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: SPARKTechnologies
+$kref: '#/ckan/github/schlosrat/SPARK'
+$vref: '#/ckan/space-warp'
+license: MIT
+tags:
+  - config
+depends:
+  - name: SpaceWarp
+  - name: LuxsFlamesandOrnaments
+install:
+  - find: SPARK
+    install_to: BepInEx/plugins
+x_netkan_override:
+  - version: '0.1.4.1'
+    override:
+      ksp_version_max: '0.1.4'
+---
+spec_version: v1.34
 identifier: SPARKTechnologies
 $kref: '#/ckan/spacedock/3470'
 $vref: '#/ckan/space-warp'
@@ -11,4 +29,3 @@ depends:
 install:
   - find: SPARK
     install_to: BepInEx/plugins
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/SpaceWarp.netkan
+++ b/NetKAN/SpaceWarp.netkan
@@ -1,4 +1,31 @@
-spec_version: v1.32
+spec_version: v1.34
+identifier: SpaceWarp
+name: SpaceWarp
+$kref: '#/ckan/github/SpaceWarpDev/SpaceWarp'
+x_netkan_version_edit:
+  find: 'spacewarp-'
+  replace: ''
+  strict: false
+$vref: '#/ckan/space-warp'
+license: MIT
+tags:
+  - plugin
+  - library
+depends:
+  - name: BepInEx
+  - name: UITKforKSP2
+install:
+  - find: BepInEx
+    install_to: GameRoot
+    include_only:
+      - patchers
+      - plugins
+x_netkan_override:
+  - version: '1.7.0'
+    override:
+      ksp_version_max: '0.2.0'
+---
+spec_version: v1.34
 identifier: SpaceWarp
 name: SpaceWarp
 $kref: '#/ckan/spacedock/3277'

--- a/NetKAN/TexturesUtilitieseXpanded.netkan
+++ b/NetKAN/TexturesUtilitieseXpanded.netkan
@@ -1,4 +1,18 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: TexturesUtilitieseXpanded
+$kref: '#/ckan/github/LuxStice/TUX'
+$vref: '#/ckan/space-warp'
+license: MIT
+tags:
+  - plugin
+  - graphics
+depends:
+  - name: SpaceWarp
+install:
+  - find: tux
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: TexturesUtilitieseXpanded
 $kref: '#/ckan/spacedock/3364'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/TheNuclearOption.netkan
+++ b/NetKAN/TheNuclearOption.netkan
@@ -1,4 +1,21 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: TheNuclearOption
+$kref: '#/ckan/github/schlosrat/TNO'
+$vref: '#/ckan/space-warp'
+license: MIT
+tags:
+  - config
+depends:
+  - name: SpaceWarp
+install:
+  - find: TNO
+    install_to: BepInEx/plugins
+x_netkan_override:
+  - version: '0.3.0'
+    override:
+      ksp_version_max: '0.1.5'
+---
+spec_version: v1.34
 identifier: TheNuclearOption
 $kref: '#/ckan/spacedock/3471'
 $vref: '#/ckan/space-warp'
@@ -10,4 +27,3 @@ depends:
 install:
   - find: TNO
     install_to: BepInEx/plugins
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/ToggleNotifications.netkan
+++ b/NetKAN/ToggleNotifications.netkan
@@ -1,4 +1,25 @@
-spec_version: v1.32
+spec_version: v1.34
+identifier: ToggleNotifications
+$kref: '#/ckan/github/cvusmo/Toggle-Notifications'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - plugin
+depends:
+  - name: SpaceWarp
+install:
+  - find_regexp: Toggle ?Notifications.*
+    install_to: BepInEx/plugins
+x_netkan_override:
+  - version: '0.3.0.1'
+    override:
+      ksp_version_max: '0.1.4'
+---
+spec_version: v1.34
 identifier: ToggleNotifications
 $kref: '#/ckan/spacedock/3377'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/UIScaler.netkan
+++ b/NetKAN/UIScaler.netkan
@@ -1,4 +1,17 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: UIScaler
+$kref: '#/ckan/github/Halbann/UIScaler'
+$vref: '#/ckan/space-warp'
+license: CC-BY-SA-4.0
+tags:
+  - plugin
+depends:
+  - name: SpaceWarp
+install:
+  - find: UIScaler
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: UIScaler
 $kref: '#/ckan/spacedock/3291'
 $vref: '#/ckan/space-warp'

--- a/NetKAN/UITKforKSP2.netkan
+++ b/NetKAN/UITKforKSP2.netkan
@@ -1,4 +1,22 @@
-spec_version: v1.32
+spec_version: v1.34
+identifier: UITKforKSP2
+$kref: '#/ckan/github/UitkForKsp2/UitkForKsp2'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - plugin
+  - library
+depends:
+  - name: BepInEx
+install:
+  - find: UitkForKsp2
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: UITKforKSP2
 $kref: '#/ckan/spacedock/3363'
 $vref: '#/ckan/space-warp'
@@ -9,9 +27,5 @@ tags:
 depends:
   - name: BepInEx
 install:
-  - find: BepInEx
-    install_to: GameRoot
-    include_only:
-      - patchers
-      - plugins
-x_via: Automated SpaceDock CKAN submission
+  - find: UitkForKsp2
+    install_to: BepInEx/plugins

--- a/NetKAN/WMCCModules.netkan
+++ b/NetKAN/WMCCModules.netkan
@@ -1,4 +1,21 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: WMCCModules
+$kref: '#/ckan/github/cheese3660/WMCCModules'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - plugin
+depends:
+  - name: SpaceWarp
+install:
+  - find: WMCCModules
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: WMCCModules
 $kref: '#/ckan/spacedock/3530'
 $vref: '#/ckan/space-warp'
@@ -10,4 +27,3 @@ depends:
 install:
   - find: WMCCModules
     install_to: BepInEx/plugins
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/WheresMyCrewCapsule.netkan
+++ b/NetKAN/WheresMyCrewCapsule.netkan
@@ -1,4 +1,31 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: WheresMyCrewCapsule
+$kref: '#/ckan/github/cheese3660/WheresMyCrewCapsule'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: MIT
+tags:
+  - config
+  - tech-tree
+  - career
+  - uncrewed
+  - science
+depends:
+  - name: SpaceWarp
+  - name: PatchManager
+  - name: WMCCModules
+install:
+  - find: WheresMyCrewCapsule
+    install_to: BepInEx/plugins
+x_netkan_override:
+  - version: '0.0.4'
+    override:
+      ksp_version_max: '0.2.0'
+---
+spec_version: v1.34
 identifier: WheresMyCrewCapsule
 $kref: '#/ckan/spacedock/3531'
 $vref: '#/ckan/space-warp'
@@ -16,4 +43,3 @@ depends:
 install:
   - find: WheresMyCrewCapsule
     install_to: BepInEx/plugins
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/kRPC2.netkan
+++ b/NetKAN/kRPC2.netkan
@@ -1,4 +1,23 @@
-spec_version: v1.18
+spec_version: v1.34
+identifier: kRPC2
+$kref: '#/ckan/github/krpc/krpc2'
+$vref: '#/ckan/space-warp'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+license: GPL-3.0
+tags:
+  - plugin
+  - app
+  - control
+depends:
+  - name: SpaceWarp
+install:
+  - find: kRPC2
+    install_to: BepInEx/plugins
+---
+spec_version: v1.34
 identifier: kRPC2
 $kref: '#/ckan/spacedock/3322'
 $vref: '#/ckan/space-warp'


### PR DESCRIPTION
In KSP-CKAN/CKAN#3877 we added the ability to list multiple download hosts per mod. This was released in CKAN v1.34.0 about 17 days ago. KSP-CKAN/NetKAN#9882 was the first usage of this about 15 days ago, and so far there have been no reports of problems.

Now all KSP2 mods that have GitHub repos with releases with assets have both SpaceDock and GitHub downloads listed. One mod that formerly only had a GitHub link now has a SpaceDock link as well. In all cases the GItHub section is listed before SpaceDock to account for SpaceDock's lower reliability and typically slower download speeds.

`x_version_edit` is used to create consistent version strings as needed (typically to remove a `v` prefix on GitHub that is absent from SpaceDock).

`x_netkan_override` is used to simulate the current value of SpaceDock's game version compatibility field for GitHub as needed. I think we should make this unnecessary by updating `netkan.exe` to merge game versions more intelligently, but I wanted to get this set up with the current code first. An alternative approach would be to remove the `$vref` from the GitHub section, but this isn't great practice and would generate warnings about `swinfo.json` existing without a `$vref`.

These mods have inconsistent latest versions between the two hosts, which causes inflation to fail or trip the auto-epoch logic, so they're omitted: `HUMANS`, `IWishTheyMadeUICustomizable`, `K2D2`, `KerbalView`, `LazyOrbitBoosted`, `MicroEngineer`, `NodeManager`, `SORRY`, `ShowKSP2Events`, `CustomFlags`, `Starhopper`, `SkipSplashScreen`, `WASDForVAB`.

`SORRY` and `Starhopper` are not included here because their `swinfo.json` files' invalid `version_check` links cause inflation errors.

Note that the `spec_version` is updated, so if users complain about not seeing the latest updates for any of these mods, make sure they're on the latest CKAN.
