### PR TITLE
Multi-download for Inputbinder

### DIFF
--- a/NetKAN/Inputbinder.netkan
+++ b/NetKAN/Inputbinder.netkan
@@ -1,6 +1,6 @@
 spec_version: v1.34
 identifier: Inputbinder
-$kref: '#/ckan/spacedock/3422'
+$kref: '#/ckan/github/Codenade/ksp2-inputbinder'
 license: MIT
 tags:
   - plugin


### PR DESCRIPTION
This was in #125 but the extra section just duplicated the same `$kref`.
Now it points to GitHub.
