### PR TITLE
Remove multi-download compatibility overrides

### DIFF
--- a/NetKAN/BurnController.netkan
+++ b/NetKAN/BurnController.netkan
@@ -15,10 +15,6 @@ depends:
 install:
   - find: BurnController
     install_to: BepInEx/plugins
-x_netkan_override:
-  - version: '0.8.1'
-    override:
-      ksp_version_max: '0.1.1'
 ---
 spec_version: v1.34
 identifier: BurnController

--- a/NetKAN/CommunityFixes.netkan
+++ b/NetKAN/CommunityFixes.netkan
@@ -15,10 +15,6 @@ depends:
 install:
   - find: CommunityFixes
     install_to: BepInEx/plugins
-x_netkan_override:
-  - version: '0.11.0'
-    override:
-      ksp_version_max: '0.2.0'
 ---
 spec_version: v1.34
 identifier: CommunityFixes

--- a/NetKAN/HideOrbits.netkan
+++ b/NetKAN/HideOrbits.netkan
@@ -14,10 +14,6 @@ depends:
 install:
   - find: HideOrbits
     install_to: BepInEx/plugins
-x_netkan_override:
-  - version: '0.5.0'
-    override:
-      ksp_version_max: '0.2.0'
 ---
 spec_version: v1.34
 identifier: HideOrbits

--- a/NetKAN/Kalkulator.netkan
+++ b/NetKAN/Kalkulator.netkan
@@ -15,10 +15,6 @@ depends:
 install:
   - find: kalkulator
     install_to: BepInEx/plugins
-x_netkan_override:
-  - version: '1.0.2'
-    override:
-      ksp_version_max: '0.1.1'
 ---
 spec_version: v1.34
 identifier: Kalkulator

--- a/NetKAN/KerbalLifeHacks.netkan
+++ b/NetKAN/KerbalLifeHacks.netkan
@@ -14,10 +14,6 @@ depends:
 install:
   - find: KerbalLifeHacks
     install_to: BepInEx/plugins
-x_netkan_override:
-  - version: '1.0.0'
-    override:
-      ksp_version_max: '0.2.0'
 ---
 spec_version: v1.34
 identifier: KerbalLifeHacks

--- a/NetKAN/KerbalLifeSupportSystem.netkan
+++ b/NetKAN/KerbalLifeSupportSystem.netkan
@@ -19,10 +19,6 @@ depends:
 install:
   - find: KerbalLifeSupportSystem
     install_to: BepInEx/plugins
-x_netkan_override:
-  - version: '0.5.2'
-    override:
-      ksp_version_max: '0.2.0'
 ---
 spec_version: v1.34
 identifier: KerbalLifeSupportSystem

--- a/NetKAN/KerbonautManager.netkan
+++ b/NetKAN/KerbonautManager.netkan
@@ -16,10 +16,6 @@ depends:
 install:
   - find: kerbonaut_manager
     install_to: BepInEx/plugins
-x_netkan_override:
-  - version: '0.2.3'
-    override:
-      ksp_version_max: '0.2.0'
 ---
 spec_version: v1.34
 identifier: KerbonautManager

--- a/NetKAN/PatchManager.netkan
+++ b/NetKAN/PatchManager.netkan
@@ -18,13 +18,6 @@ install:
     include_only:
       - patchers
       - plugins
-x_netkan_override:
-  - version: '0.8.0'
-    override:
-      ksp_version_max: '0.2.0'
-  - version: '0.7.3'
-    override:
-      ksp_version_max: '0.2.0'
 ---
 spec_version: v1.34
 identifier: PatchManager

--- a/NetKAN/ResonantOrbitCalculator.netkan
+++ b/NetKAN/ResonantOrbitCalculator.netkan
@@ -11,10 +11,6 @@ depends:
 install:
   - find: resonant_orbit_calculator
     install_to: BepInEx/plugins
-x_netkan_override:
-  - version: '0.6.2'
-    override:
-      ksp_version_max: '0.1.4'
 ---
 spec_version: v1.34
 identifier: ResonantOrbitCalculator

--- a/NetKAN/SPARKTechnologies.netkan
+++ b/NetKAN/SPARKTechnologies.netkan
@@ -11,10 +11,6 @@ depends:
 install:
   - find: SPARK
     install_to: BepInEx/plugins
-x_netkan_override:
-  - version: '0.1.4.1'
-    override:
-      ksp_version_max: '0.1.4'
 ---
 spec_version: v1.34
 identifier: SPARKTechnologies

--- a/NetKAN/SpaceWarp.netkan
+++ b/NetKAN/SpaceWarp.netkan
@@ -20,10 +20,6 @@ install:
     include_only:
       - patchers
       - plugins
-x_netkan_override:
-  - version: '1.7.0'
-    override:
-      ksp_version_max: '0.2.0'
 ---
 spec_version: v1.34
 identifier: SpaceWarp

--- a/NetKAN/TheNuclearOption.netkan
+++ b/NetKAN/TheNuclearOption.netkan
@@ -10,10 +10,6 @@ depends:
 install:
   - find: TNO
     install_to: BepInEx/plugins
-x_netkan_override:
-  - version: '0.3.0'
-    override:
-      ksp_version_max: '0.1.5'
 ---
 spec_version: v1.34
 identifier: TheNuclearOption

--- a/NetKAN/ToggleNotifications.netkan
+++ b/NetKAN/ToggleNotifications.netkan
@@ -14,10 +14,6 @@ depends:
 install:
   - find_regexp: Toggle ?Notifications.*
     install_to: BepInEx/plugins
-x_netkan_override:
-  - version: '0.3.0.1'
-    override:
-      ksp_version_max: '0.1.4'
 ---
 spec_version: v1.34
 identifier: ToggleNotifications

--- a/NetKAN/WheresMyCrewCapsule.netkan
+++ b/NetKAN/WheresMyCrewCapsule.netkan
@@ -20,10 +20,6 @@ depends:
 install:
   - find: WheresMyCrewCapsule
     install_to: BepInEx/plugins
-x_netkan_override:
-  - version: '0.0.4'
-    override:
-      ksp_version_max: '0.2.0'
 ---
 spec_version: v1.34
 identifier: WheresMyCrewCapsule


### PR DESCRIPTION
These overrides were added to work around the `ksp_version mixed with ksp_version_(min|max)` errors in KSP-CKAN/KSP2-NetKAN#125.
They're no longer needed after KSP-CKAN/CKAN#3991.