### PR TITLE
SPARKTechnologies no longer releases on GitHub

### DIFF
--- a/NetKAN/SPARKTechnologies.netkan
+++ b/NetKAN/SPARKTechnologies.netkan
@@ -1,21 +1,5 @@
 spec_version: v1.34
 identifier: SPARKTechnologies
-$kref: '#/ckan/github/schlosrat/SPARK'
-$vref: '#/ckan/space-warp'
-license: MIT
-tags:
-  - config
-depends:
-  - name: SpaceWarp
-  - name: LuxsFlamesandOrnaments
-  - name: CommunityResources
-  - name: PatchManager
-install:
-  - find: SPARK
-    install_to: BepInEx/plugins
----
-spec_version: v1.34
-identifier: SPARKTechnologies
 $kref: '#/ckan/spacedock/3470'
 $vref: '#/ckan/space-warp'
 license: MIT


### PR DESCRIPTION
![image](https://github.com/KSP-CKAN/KSP2-NetKAN/assets/1559108/b39cc827-14b3-460b-b44a-dcebec36b4a5)

The GitHub releases are all gone.

- <https://github.com/schlosrat/SPARK/releases>
