### PR TITLE
Add missing depends on 25xKerbolarSystem for ScaledMissions

### DIFF
--- a/NetKAN/ScaledMissions.netkan
+++ b/NetKAN/ScaledMissions.netkan
@@ -6,6 +6,7 @@ tags:
 depends:
   - name: SpaceWarp
   - name: PatchManager
+  - name: 25xKerbolarSystem
 install:
   - find: ScaledMissions
     install_to: BepInEx/plugins


### PR DESCRIPTION
This mod has an inflation warning:

![image](https://github.com/user-attachments/assets/4ee5a414-94c6-4263-a03a-a911a7984670)

There is no mod by that name, but it seems to be a reference to the one from #131.

Now that dependency is added. The warning will stay, but at least the relationships are fixed.