### PR TITLE
Add conflict betweek forks of LazyOrbit

### DIFF
--- a/NetKAN/LazyOrbitBoosted.netkan
+++ b/NetKAN/LazyOrbitBoosted.netkan
@@ -3,6 +3,10 @@ $kref: '#/ckan/spacedock/3410'
 $vref: '#/ckan/space-warp'
 tags:
   - plugin
+provides:
+  - LazyOrbit
+conflicts:
+  - name: LazyOrbit
 depends:
   - name: SpaceWarp
 install:


### PR DESCRIPTION
LazyOrbitBoosted is a fork of LazyOrbit that installs to the same path, so they can't be installed at the same time.
Now they conflict.

Fixes #197.
