### PR TITLE
Fix MissionTreeExpanded install

### DIFF
--- a/NetKAN/MissionTreeExpanded.netkan
+++ b/NetKAN/MissionTreeExpanded.netkan
@@ -14,4 +14,6 @@ tags:
 depends:
   - name: SpaceWarp
   - name: PatchManager
-x_via: Automated SpaceDock CKAN submission
+install:
+  - find: MissionTreeExpanded
+    install_to: BepInEx/plugins


### PR DESCRIPTION
This mod is supposed to be in `BepInEx/plugins`, but it's using the default of `GameData/Mods` (which the stock mod loader allegedly was going to use someday, but now will never be finished).
