### PR TITLE
Remove patchers from PatchManager include_only

### DIFF
--- a/NetKAN/PatchManager.netkan
+++ b/NetKAN/PatchManager.netkan
@@ -5,12 +5,6 @@ x_netkan_version_edit:
   find: ^v
   replace: ''
   strict: false
-install:
-  - find: BepInEx
-    install_to: GameRoot
-    include_only:
-      - patchers
-      - plugins
 ---
 identifier: PatchManager
 $kref: '#/ckan/spacedock/3482'
@@ -25,5 +19,4 @@ install:
   - find: BepInEx
     install_to: GameRoot
     include_only:
-      - patchers
       - plugins


### PR DESCRIPTION
PatchManager currently distributes a `patchers` folder containing just an empty folder but no files:

![image](https://github.com/user-attachments/assets/7c2647be-d532-4960-9826-d8dab1cf64a1)

This causes the `InstallsFilesValidator` to think that `patchers` in the `install[].include_only` doesn't match anything.

![image](https://github.com/user-attachments/assets/c390eaa0-6dbe-436b-9064-4d980ab519ef)

Now `patchers` is removed from `include_only`.